### PR TITLE
Add norynth/ros2-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,3 +210,7 @@ Companies, labs, and projects using ROS across domains from logistics and agricu
 |**Robotics Stackexchange** | [Link](https://robotics.stackexchange.com/)|
 
 **ROS Agriculture Slack Channel**
+
+## Packages
+
+- [norynth/ros2-bridge](https://github.com/norynth/ros2-bridge) - ROS2 package for fleet management, telemetry streaming, and command dispatch to the Norynth Robotics platform.


### PR DESCRIPTION
Adds norynth/ros2-bridge to the Packages section. ROS2 package for fleet management and cloud integration.